### PR TITLE
feat: #3 Implement JusoAPI integration for region data

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -61,4 +61,6 @@ dependencies {
     implementation(libs.hilt.android)
     ksp(libs.hilt.android.compiler)
     implementation(libs.androidx.hilt.navigation.compose)
+    implementation("com.squareup.retrofit2:retrofit:2.12.0")
+    implementation("com.squareup.retrofit2:converter-gson:2.12.0")
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.INTERNET" />
+
     <application
         android:name=".UMCApplication"
         android:allowBackup="true"

--- a/app/src/main/java/umc/hackathon/data/datasource/DefaultRegionDataSource.kt
+++ b/app/src/main/java/umc/hackathon/data/datasource/DefaultRegionDataSource.kt
@@ -1,0 +1,17 @@
+package umc.hackathon.data.datasource
+
+import umc.hackathon.data.network.JusoAPI
+import umc.hackathon.model.Region
+import javax.inject.Inject
+
+class DefaultRegionDataSource @Inject constructor(private val jusoAPI: JusoAPI) : RegionDataSource {
+    override suspend fun getAllRegions(): List<Region> {
+        val response = jusoAPI.getRegCodes("*00000000")
+        return response.regcodes.map { regCode ->
+            Region(
+                code = regCode.code,
+                name = regCode.name
+            )
+        }
+    }
+}

--- a/app/src/main/java/umc/hackathon/data/datasource/RegionDataSource.kt
+++ b/app/src/main/java/umc/hackathon/data/datasource/RegionDataSource.kt
@@ -1,0 +1,7 @@
+package umc.hackathon.data.datasource
+
+import umc.hackathon.model.Region
+
+interface RegionDataSource {
+    suspend fun getAllRegions(): List<Region>
+}

--- a/app/src/main/java/umc/hackathon/data/network/JusoAPI.kt
+++ b/app/src/main/java/umc/hackathon/data/network/JusoAPI.kt
@@ -1,0 +1,20 @@
+package umc.hackathon.data.network
+
+import retrofit2.Response
+import retrofit2.http.GET
+import retrofit2.http.Query
+import umc.hackathon.data.network.model.response.RegCodeResponse
+
+interface JusoAPI {
+    /**
+     * 행정구역 코드를 조회하는 API
+     * @param pattern 검색할 코드 패턴 (예: "11*", "*00000000")
+     * @param ignoreZero '동'만 조회할지 여부 (true일 경우)
+     * @return API 응답
+     */
+    @GET("v1/regcodes")
+    suspend fun getRegCodes(
+        @Query("regcode_pattern") pattern: String,
+        @Query("is_ignore_zero") ignoreZero: Boolean? = null
+    ): RegCodeResponse
+}

--- a/app/src/main/java/umc/hackathon/data/network/model/response/RegCodeResponse.kt
+++ b/app/src/main/java/umc/hackathon/data/network/model/response/RegCodeResponse.kt
@@ -1,0 +1,10 @@
+package umc.hackathon.data.network.model.response
+
+data class RegCodeResponse(
+    val regcodes: List<RegCode>
+)
+
+data class RegCode(
+    val code: String,
+    val name: String
+)

--- a/app/src/main/java/umc/hackathon/data/repository/DefaultRegionRepository.kt
+++ b/app/src/main/java/umc/hackathon/data/repository/DefaultRegionRepository.kt
@@ -1,0 +1,14 @@
+package umc.hackathon.data.repository
+
+import umc.hackathon.data.datasource.RegionDataSource
+import umc.hackathon.domain.RegionRepository
+import umc.hackathon.model.Region
+import javax.inject.Inject
+
+internal class DefaultRegionRepository @Inject constructor(private val regionDataSource: RegionDataSource) :
+    RegionRepository {
+    override suspend fun getAllRegions(): List<Region> {
+        return regionDataSource.getAllRegions()
+    }
+
+}

--- a/app/src/main/java/umc/hackathon/di/DatasourceBindModule.kt
+++ b/app/src/main/java/umc/hackathon/di/DatasourceBindModule.kt
@@ -4,7 +4,9 @@ import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import umc.hackathon.data.datasource.DefaultRegionDataSource
 import umc.hackathon.data.datasource.DefaultTestDataSource
+import umc.hackathon.data.datasource.RegionDataSource
 import umc.hackathon.data.datasource.TestDataSource
 import umc.hackathon.data.repository.DefaultTestRepository
 import umc.hackathon.domain.TestRepository
@@ -18,4 +20,10 @@ abstract class DatasourceBindModule {
     internal abstract fun bindTestDataSource(
         testDataSourceImpl: DefaultTestDataSource
     ): TestDataSource
+
+    @Binds
+    @Singleton
+    internal abstract fun bindRegionDataSource(
+        regionDataSourceImpl: DefaultRegionDataSource
+    ): RegionDataSource
 }

--- a/app/src/main/java/umc/hackathon/di/NetworkModule.kt
+++ b/app/src/main/java/umc/hackathon/di/NetworkModule.kt
@@ -1,0 +1,32 @@
+package umc.hackathon.di
+
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+import umc.hackathon.data.network.JusoAPI
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+class NetworkModule {
+
+    private val JUSO_API_BASE_URL = "https://grpc-proxy-server-mkvo6j4wsq-du.a.run.app/"
+
+    @Provides
+    @Singleton
+    fun provideRetrofit(): Retrofit {
+        return Retrofit.Builder()
+            .baseUrl(JUSO_API_BASE_URL)
+            .addConverterFactory(GsonConverterFactory.create())
+            .build()
+    }
+
+    @Provides
+    @Singleton
+    fun provideApiService(retrofit: Retrofit): JusoAPI {
+        return retrofit.create(JusoAPI::class.java)
+    }
+}

--- a/app/src/main/java/umc/hackathon/di/RepositoryBindModule.kt
+++ b/app/src/main/java/umc/hackathon/di/RepositoryBindModule.kt
@@ -4,7 +4,9 @@ import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import umc.hackathon.data.repository.DefaultRegionRepository
 import umc.hackathon.data.repository.DefaultTestRepository
+import umc.hackathon.domain.RegionRepository
 import umc.hackathon.domain.TestRepository
 import javax.inject.Singleton
 
@@ -16,4 +18,10 @@ abstract class RepositoryBindModule {
     internal abstract fun bindTestRepository(
         testRepositoryImpl: DefaultTestRepository
     ): TestRepository
+
+    @Binds
+    @Singleton
+    internal abstract fun bindRegionRepository(
+        regionRepositoryImpl: DefaultRegionRepository
+    ): RegionRepository
 }

--- a/app/src/main/java/umc/hackathon/domain/RegionRepository.kt
+++ b/app/src/main/java/umc/hackathon/domain/RegionRepository.kt
@@ -1,0 +1,7 @@
+package umc.hackathon.domain
+
+import umc.hackathon.model.Region
+
+interface RegionRepository {
+    suspend fun getAllRegions(): List<Region>
+}

--- a/app/src/main/java/umc/hackathon/model/Region.kt
+++ b/app/src/main/java/umc/hackathon/model/Region.kt
@@ -1,0 +1,6 @@
+package umc.hackathon.model
+
+data class Region(
+    val name: String,
+    val code: String
+)

--- a/app/src/main/java/umc/hackathon/presentation/ui/main/MainViewModel.kt
+++ b/app/src/main/java/umc/hackathon/presentation/ui/main/MainViewModel.kt
@@ -1,13 +1,17 @@
 package umc.hackathon.presentation.ui.main
 
+import android.util.Log
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import umc.hackathon.domain.RegionRepository
 import umc.hackathon.domain.TestRepository
 import javax.inject.Inject
 
 @HiltViewModel
-class MainViewModel @Inject constructor(private val testRepository: TestRepository) : ViewModel() {
+class MainViewModel @Inject constructor(private val regionRepository: RegionRepository) :
+    ViewModel() {
     init {
-        testRepository.foo()
     }
 }


### PR DESCRIPTION
This commit introduces the necessary components to fetch region data using the JusoAPI.

- Add Retrofit dependencies to `app/build.gradle.kts`.
- Request internet permission in `AndroidManifest.xml`.
- Create `NetworkModule` to provide Retrofit and JusoAPI instances.
- Define `JusoAPI` interface with `getRegCodes` method.
- Create `RegCodeResponse` and `RegCode` data classes for API response.
- Create `Region` data class in `model` package.
- Implement `RegionDataSource` and `DefaultRegionDataSource` to fetch and map region data.
- Implement `RegionRepository` and `DefaultRegionRepository` to provide region data to the domain layer.
- Update `DatasourceBindModule` and `RepositoryBindModule` to bind new data source and repository.
- Modify `MainViewModel` to use `RegionRepository` (currently unused).