### PR TITLE
Define and apply custom color scheme

### DIFF
--- a/app/src/main/java/umc/hackathon/core/designsystem/theme/Color.kt
+++ b/app/src/main/java/umc/hackathon/core/designsystem/theme/Color.kt
@@ -1,11 +1,68 @@
 package umc.hackathon.core.designsystem.theme
 
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.graphics.Color
 
-val Purple80 = Color(0xFFD0BCFF)
-val PurpleGrey80 = Color(0xFFCCC2DC)
-val Pink80 = Color(0xFFEFB8C8)
+@Immutable
+data class HackathonColorScheme(
+    val mainGreen300: Color,
+    val mainGreen200: Color,
+    val mainGreen100: Color,
+    val mainYellow300: Color,
+    val mainYellow200: Color,
+    val mainYellow100: Color,
+    val black: Color,
+    val gray700: Color,
+    val gray600: Color,
+    val gray500: Color,
+    val gray400: Color,
+    val gray300: Color,
+    val gray200: Color,
+    val gray100: Color,
+    val white: Color,
+    val negativeColor: Color,
+    val positiveColor: Color
+)
 
-val Purple40 = Color(0xFF6650a4)
-val PurpleGrey40 = Color(0xFF625b71)
-val Pink40 = Color(0xFF7D5260)
+val LocalHackathonColorScheme = staticCompositionLocalOf {
+    HackathonColorScheme(
+        mainGreen300 = Color.Unspecified,
+        mainGreen200 = Color.Unspecified,
+        mainGreen100 = Color.Unspecified,
+        mainYellow300 = Color.Unspecified,
+        mainYellow200 = Color.Unspecified,
+        mainYellow100 = Color.Unspecified,
+        black = Color.Unspecified,
+        gray700 = Color.Unspecified,
+        gray600 = Color.Unspecified,
+        gray500 = Color.Unspecified,
+        gray400 = Color.Unspecified,
+        gray300 = Color.Unspecified,
+        gray200 = Color.Unspecified,
+        gray100 = Color.Unspecified,
+        white = Color.Unspecified,
+        negativeColor = Color.Unspecified,
+        positiveColor = Color.Unspecified
+    )
+}
+
+internal val basicHackathonColorScheme = HackathonColorScheme(
+    mainGreen300 = Color(0xFF5FCF88),
+    mainGreen200 = Color(0xFF89E1B6),
+    mainGreen100 = Color(0xFFC0F0DB),
+    mainYellow300 = Color(0xFFFDF392),
+    mainYellow200 = Color(0xFFFEF8BD),
+    mainYellow100 = Color(0xFFFFFCDD),
+    black = Color(0xFF101010),
+    gray700 = Color(0xFF2D2D2D),
+    gray600 = Color(0xFF4B4B4B),
+    gray500 = Color(0xFF5F615E),
+    gray400 = Color(0xFFA8A8A8),
+    gray300 = Color(0xFFE0E0E0),
+    gray200 = Color(0xFFF0F0EF),
+    gray100 = Color(0xFFF6F6F6),
+    white = Color(0xFFFFFFFF),
+    negativeColor = Color(0xFFEC6964),
+    positiveColor = Color(0xFF6FDC83)
+)

--- a/app/src/main/java/umc/hackathon/core/designsystem/theme/Theme.kt
+++ b/app/src/main/java/umc/hackathon/core/designsystem/theme/Theme.kt
@@ -8,50 +8,25 @@ import androidx.compose.material3.dynamicDarkColorScheme
 import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.platform.LocalContext
-
-private val DarkColorScheme = darkColorScheme(
-    primary = Purple80,
-    secondary = PurpleGrey80,
-    tertiary = Pink80
-)
-
-private val LightColorScheme = lightColorScheme(
-    primary = Purple40,
-    secondary = PurpleGrey40,
-    tertiary = Pink40
-
-    /* Other default colors to override
-    background = Color(0xFFFFFBFE),
-    surface = Color(0xFFFFFBFE),
-    onPrimary = Color.White,
-    onSecondary = Color.White,
-    onTertiary = Color.White,
-    onBackground = Color(0xFF1C1B1F),
-    onSurface = Color(0xFF1C1B1F),
-    */
-)
 
 @Composable
 fun UMCHackathonTheme(
-    darkTheme: Boolean = isSystemInDarkTheme(),
-    // Dynamic color is available on Android 12+
-    dynamicColor: Boolean = true,
     content: @Composable () -> Unit
 ) {
-    val colorScheme = when {
-        dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
-            val context = LocalContext.current
-            if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
-        }
-
-        darkTheme -> DarkColorScheme
-        else -> LightColorScheme
+    CompositionLocalProvider(
+        LocalHackathonColorScheme provides basicHackathonColorScheme
+    ) {
+        MaterialTheme(
+            typography = Typography,
+            content = content
+        )
     }
+}
 
-    MaterialTheme(
-        colorScheme = colorScheme,
-        typography = Typography,
-        content = content
-    )
+object UMCHackathonTheme {
+    val colorScheme: HackathonColorScheme
+        @Composable
+        get() = LocalHackathonColorScheme.current
 }


### PR DESCRIPTION
This commit introduces a custom color scheme (`HackathonColorScheme`) for the application, replacing the default Material Design color schemes.

- `HackathonColorScheme` data class defines various color properties like main greens, yellows, grays, black, white, negative, and positive colors.
- `LocalHackathonColorScheme` is a `staticCompositionLocalOf` to provide the color scheme.
- `basicHackathonColorScheme` provides the default color values for the custom scheme.
- `UMCHackathonTheme` composable now uses `CompositionLocalProvider` to make `basicHackathonColorScheme` available through `LocalHackathonColorScheme`.
- An object `UMCHackathonTheme` is added to allow easy access to the current `HackathonColorScheme` via `UMCHackathonTheme.colorScheme`.
- Removed the usage of `DarkColorScheme`, `LightColorScheme`, `dynamicDarkColorScheme`, and `dynamicLightColorScheme`.